### PR TITLE
add docker image check for service releases with state drift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.62.1
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.47.1
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,10 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.1 h1:+dn/xF/05utS7tUhjIc
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.1/go.mod h1:hyAGz30LHdm5KBZDI58MXx5lDVZ5CUfvfTZvMu4HCZo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.62.1 h1:gqN14m9ds7GOyB9B3es0Gv0xf1OaPpqmU1qUGXh8sR0=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.62.1/go.mod h1:bfVI9myeahAr36mMKS/dtXsU4inMeZd9CCYe1kcHmHA=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.47.1 h1:gwqCrRvz+vnhWyG9/WSzo6HspAO5mWXBeYo9ELFUcIM=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.47.1/go.mod h1:VVqrGCL0/zQif1J6axnyUBVRf6lySV5/QhxV9RspEHY=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.61.1 h1:C9YpiBJwF9ORx1PNLK7hIT9edNcezQs+ioCT64414+8=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.61.1/go.mod h1:NzX/k/6nc9X5l1NShl1p2PLbBZ2IohBcD0d76o7uPtw=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 h1:6+lZi2JeGKtCraAj1rpoZfKqnQ9SptseRZioejfUOLM=

--- a/pkg/worker/handler/operator/cloudformation/cloudformation.go
+++ b/pkg/worker/handler/operator/cloudformation/cloudformation.go
@@ -1,0 +1,67 @@
+package cloudformation
+
+import (
+	"fmt"
+
+	"github.com/0xSplits/kayron/pkg/cache"
+	"github.com/0xSplits/kayron/pkg/envvar"
+	"github.com/0xSplits/kayron/pkg/release/schema/service"
+	"github.com/0xSplits/otelgo/registry"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	Metric = "deployment_event"
+)
+
+type Config struct {
+	Art cache.Interface[string, string]
+	Aws aws.Config
+	Env envvar.Env
+	Log logger.Interface
+	Met metric.Meter
+	Ser cache.Interface[int, service.Service]
+}
+
+type CloudFormation struct {
+	art cache.Interface[string, string]
+	cfc *cloudformation.Client
+	log logger.Interface
+	reg registry.Interface
+	ser cache.Interface[int, service.Service]
+}
+
+func New(c Config) *CloudFormation {
+	if c.Art == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Art must not be empty", c)))
+	}
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
+	if c.Log == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+	if c.Ser == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Ser must not be empty", c)))
+	}
+
+	var reg registry.Interface
+	{
+		reg = newRegistry(c.Env.Environment, c.Log, c.Met)
+	}
+
+	return &CloudFormation{
+		art: c.Art,
+		cfc: cloudformation.NewFromConfig(c.Aws),
+		log: c.Log,
+		reg: reg,
+		ser: c.Ser,
+	}
+}

--- a/pkg/worker/handler/operator/cloudformation/ensure.go
+++ b/pkg/worker/handler/operator/cloudformation/ensure.go
@@ -1,0 +1,13 @@
+package cloudformation
+
+func (h *CloudFormation) Ensure() error {
+
+	// TODO
+	//
+	//     check for drift
+	//     apply update, if any
+	//     emit deployment event, if updated
+	//
+
+	return nil
+}

--- a/pkg/worker/handler/operator/cloudformation/registry.go
+++ b/pkg/worker/handler/operator/cloudformation/registry.go
@@ -1,4 +1,4 @@
-package operator
+package cloudformation
 
 import (
 	"github.com/0xSplits/otelgo/recorder"

--- a/pkg/worker/handler/operator/ensure.go
+++ b/pkg/worker/handler/operator/ensure.go
@@ -29,10 +29,6 @@ func (h *Handler) Ensure() error {
 	//        branch deployment strategy. This populates the DESIRED state of the
 	//        artifact reference.
 	//
-	//     3. TODO fetch existing image tags from configured Docker registry
-	//
-	//     4. TODO fetch existing cloudformation templates from infrastructure repo
-	//
 
 	{
 		err = parallel.Func(h.con.Ensure, h.ref.Ensure)
@@ -41,12 +37,30 @@ func (h *Handler) Ensure() error {
 		}
 	}
 
-	// TODO
+	// Once the current and desired states of the runnable service releases are
+	// known, we can run the next steps in parallel too. Additionally, we only
+	// need to do real work in those following steps, if we recognize any state
+	// drift.
 	//
-	//     check for drift
-	//     apply update, if any
-	//     emit deployment event, if updated
+	//     1. Check whether those ECR image tags exist that are specified in the
+	//        desired state of any given service release.
 	//
+	//     2. TODO fetch existing cloudformation templates from infrastructure repo
+	//
+
+	{
+		err = parallel.Func(h.reg.Ensure /* , h.inf.Ensure */)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	{
+		err = h.clo.Ensure() // TODO add business logic
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
 
 	return nil
 }

--- a/pkg/worker/handler/operator/registry/ensure.go
+++ b/pkg/worker/handler/operator/registry/ensure.go
@@ -1,0 +1,117 @@
+package registry
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/0xSplits/kayron/pkg/release/artifact"
+	"github.com/0xSplits/kayron/pkg/release/schema/service"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/xh3b4sd/choreo/parallel"
+	"github.com/xh3b4sd/tracer"
+)
+
+func (r *Registry) Ensure() error {
+	var err error
+
+	var ser []service.Service
+	for i := range r.ser.Length() {
+		var s service.Service
+		{
+			s, _ = r.ser.Search(i)
+		}
+
+		{
+			ser = append(ser, s)
+		}
+	}
+
+	// Check whether the desired Docker image exists within the underlying
+	// container registry, if the current and desired state differs.
+
+	fnc := func(i int, x service.Service) error {
+		var err error
+
+		var cur string
+		var des string
+		{
+			cur, _ = r.art.Search(artifact.ReferenceCurrent(i))
+			des, _ = r.art.Search(artifact.ReferenceDesired(i))
+		}
+
+		// We do not have to do any work here if the currently deployed service
+		// already matches the desired service release. Note that we also have to
+		// prevent the infrastructure configuration that is part of the cached
+		// services to initiate its own image lookup, because there is no image for
+		// our templates. The current setup is not optimal and a better data
+		// structure may be used in a future refactoring, so that we do not have to
+		// do these provider checks anymore.
+
+		if cur == des || x.Provider == "cloudformation" {
+			return nil
+		}
+
+		var exi bool
+		{
+			exi, err = r.imaExi(x.Docker.String(), des)
+			if err != nil {
+				return tracer.Mask(err)
+			}
+		}
+
+		var str string
+		{
+			str = strconv.FormatBool(exi)
+		}
+
+		{
+			r.art.Update(artifact.ContainerExists(i), str)
+		}
+
+		r.log.Log(
+			"level", "debug",
+			"message", "executed image check",
+			"image", x.Docker.String(),
+			"tag", des,
+			"exists", str,
+		)
+
+		return nil
+	}
+
+	{
+		err = parallel.Slice(ser, fnc)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Registry) imaExi(rep string, tag string) (bool, error) {
+	var err error
+
+	var inp *ecr.DescribeImagesInput
+	{
+		inp = &ecr.DescribeImagesInput{
+			RepositoryName: aws.String(rep),
+			ImageIds: []types.ImageIdentifier{
+				{ImageTag: aws.String(tag)},
+			},
+		}
+	}
+
+	{
+		_, err = r.ecr.DescribeImages(context.Background(), inp)
+		if isImageNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, tracer.Mask(err)
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/worker/handler/operator/registry/error.go
+++ b/pkg/worker/handler/operator/registry/error.go
@@ -1,0 +1,14 @@
+package registry
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+func isImageNotFound(err error) bool {
+	var inf *types.ImageNotFoundException
+	var rnf *types.RepositoryNotFoundException
+
+	return errors.As(err, &inf) || errors.As(err, &rnf)
+}

--- a/pkg/worker/handler/operator/registry/registry.go
+++ b/pkg/worker/handler/operator/registry/registry.go
@@ -1,0 +1,52 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/0xSplits/kayron/pkg/cache"
+	"github.com/0xSplits/kayron/pkg/envvar"
+	"github.com/0xSplits/kayron/pkg/release/schema/service"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+)
+
+type Config struct {
+	Art cache.Interface[string, string]
+	Aws aws.Config
+	Env envvar.Env
+	Log logger.Interface
+	Ser cache.Interface[int, service.Service]
+}
+
+type Registry struct {
+	art cache.Interface[string, string]
+	ecr *ecr.Client
+	env envvar.Env
+	log logger.Interface
+	ser cache.Interface[int, service.Service]
+}
+
+func New(c Config) *Registry {
+	if c.Art == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Art must not be empty", c)))
+	}
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
+	if c.Log == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+	if c.Ser == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Ser must not be empty", c)))
+	}
+
+	return &Registry{
+		art: c.Art,
+		ecr: ecr.NewFromConfig(c.Aws),
+		env: c.Env,
+		log: c.Log,
+		ser: c.Ser,
+	}
+}


### PR DESCRIPTION
In this pull request, we add the business logic for verifying whether a Docker image exists for any given service release. We need to do this because we cannot deploy a release for which there does no Docker image exist. So the business logic added here in a separate handler will later be useful once we try to figure out which service release should be deployed and which shouldn't. Below are the logs from a local test run.

```
{
  "time": "2025-08-04 10:58:11",
  "level": "debug",
  "message": "executed image check",
  "exists": "false",
  "image": "kayron",
  "tag": "v0.1.0",
  "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/worker/handler/operator/registry/ensure.go:73"
}
{
  "time": "2025-08-04 10:58:11",
  "level": "debug",
  "message": "executed image check",
  "exists": "false",
  "image": "server",
  "tag": "v0.87.15",
  "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/worker/handler/operator/registry/ensure.go:73"
}
{
  "time": "2025-08-04 10:58:11",
  "level": "debug",
  "message": "executed image check",
  "exists": "false",
  "image": "specta",
  "tag": "v0.4.1",
  "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/worker/handler/operator/registry/ensure.go:73"
}
{
  "time": "2025-08-04 10:58:11",
  "level": "debug",
  "message": "executed image check",
  "exists": "false",
  "image": "explorer",
  "tag": "v0.8.2",
  "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/worker/handler/operator/registry/ensure.go:73"
}
{
  "time": "2025-08-04 10:58:11",
  "level": "debug",
  "message": "executed image check",
  "exists": "false",
  "image": "teams",
  "tag": "v0.26.3",
  "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/worker/handler/operator/registry/ensure.go:73"
}
```