### PR TITLE
skip integration tests in dependabot pull requests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,6 +1,12 @@
 name: "integration-test"
 
-on: "push"
+on:
+  push:
+    # Dependabot has no access to the secrets that this integration test
+    # requires. So we skip running integration tests in branches that dependabot
+    # presumably created.
+    branches-ignore:
+      - "dependabot/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
I started noticing that the integration tests failed for dependabot pull requests. So here we skip this particular workflow in those branches.

> Secrets are not available to workflows triggered by Dependabot events

https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets