### PR TITLE
group dependabot updates for aws sdk related oull requests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,7 @@
 # Do not edit. This file was generated via the "workflow" command line tool.
 # More information about the tool can be found at github.com/xh3b4sd/workflow.
 #
-#     workflow create dependabot -r @xh3b4sd
+#     workflow create dependabot -c gomod:github.com/aws/aws-sdk-go-v2
 #
 
 version: 2
@@ -10,30 +10,24 @@ version: 2
 updates:
   - package-ecosystem: "docker"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
-
   - package-ecosystem: "github-actions"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
-
   - package-ecosystem: "gomod"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"


### PR DESCRIPTION
Updating dependabot so that we get 1 pull request for the AWS SDK, and not 37 of them at once. 