### PR TITLE
inject template parameters dynamically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,14 @@ go 1.24
 require (
 	github.com/0xSplits/otelgo v0.1.0
 	github.com/0xSplits/workit v0.4.1
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aws/aws-sdk-go-v2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.64.0
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/distribution/reference v0.6.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/go-cmp v0.7.0
@@ -25,10 +29,10 @@ require (
 	github.com/xh3b4sd/logger v0.11.1
 	github.com/xh3b4sd/tracer v1.0.0
 	go.opentelemetry.io/otel/metric v1.37.0
+	golang.org/x/text v0.27.0
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.3 // indirect
@@ -36,13 +40,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.64.0
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 // indirect
@@ -70,6 +71,5 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
-	golang.org/x/text v0.27.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/pkg/cache/object.go
+++ b/pkg/cache/object.go
@@ -1,8 +1,12 @@
 package cache
 
 import (
+	"fmt"
+
 	"github.com/0xSplits/kayron/pkg/release/artifact"
 	"github.com/0xSplits/kayron/pkg/release/schema/release"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // kind is a private type for private object properties in order to guarantee
@@ -23,4 +27,21 @@ type Object struct {
 
 	ind int
 	kin kind
+}
+
+// Parameter returns the CloudFormation stack parameter key for this release
+// artifact. The keys generated here have to be supported in the CloudFormation
+// template being deployed.
+func (o Object) Parameter() string {
+	cas := cases.Title(language.English)
+
+	if o.kin == Infrastructure {
+		return fmt.Sprintf("%sVersion", cas.String(o.Release.Github.String())) // e.g. InfrastructureVersion
+	}
+
+	if o.kin == Service {
+		return fmt.Sprintf("%sVersion", cas.String(o.Release.Docker.String())) // e.g. SpectaVersion
+	}
+
+	return ""
 }

--- a/pkg/cache/object_test.go
+++ b/pkg/cache/object_test.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xSplits/kayron/pkg/release/schema/release"
+	"github.com/0xSplits/kayron/pkg/release/schema/release/docker"
+	"github.com/0xSplits/kayron/pkg/release/schema/release/github"
+)
+
+func Test_Cache_Object_Parameter(t *testing.T) {
+	testCases := []struct {
+		obj Object
+		par string
+	}{
+		// Case 000
+		{
+			obj: Object{
+				Release: release.Struct{Github: github.String("infrastructure")},
+				kin:     Infrastructure,
+			},
+			par: "InfrastructureVersion",
+		},
+		// Case 001
+		{
+			obj: Object{
+				Release: release.Struct{Github: github.String("heLLowOrlD")},
+				kin:     Infrastructure,
+			},
+			par: "HelloworldVersion",
+		},
+		// Case 002
+		{
+			obj: Object{
+				Release: release.Struct{Docker: docker.String("specta")},
+				kin:     Service,
+			},
+			par: "SpectaVersion",
+		},
+		// Case 003
+		{
+			obj: Object{
+				Release: release.Struct{Docker: docker.String("fOobAR")},
+				kin:     Service,
+			},
+			par: "FoobarVersion",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			par := tc.obj.Parameter()
+			if par != tc.par {
+				t.Fatalf("expected %#v got %#v", tc.par, par)
+			}
+		})
+	}
+}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,6 +1,5 @@
 package constant
 
 const (
-	Cloudformation        = "cloudformation"
-	KayronTemplateVersion = "KayronTemplateVersion"
+	Cloudformation = "cloudformation"
 )

--- a/pkg/operator/cloudformation/ensure.go
+++ b/pkg/operator/cloudformation/ensure.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/0xSplits/kayron/pkg/cache"
-	"github.com/0xSplits/kayron/pkg/constant"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
@@ -15,11 +13,6 @@ import (
 func (c *CloudFormation) Ensure() error {
 	var err error
 
-	var inf cache.Object
-	{
-		inf = c.cac.Infrastructure()
-	}
-
 	var par []types.Parameter
 	for k, v := range c.env.CloudformationParameters {
 		par = append(par, types.Parameter{
@@ -28,15 +21,15 @@ func (c *CloudFormation) Ensure() error {
 		})
 	}
 
-	// Inject the new template version into the parameters that we are just about
-	// to deploy. Injecting this parameter after all user inputs have been applied
-	// above guarantees that only the infrastructure version as defined with its
-	// own infrastructure release will ever be applied.
+	// Inject all desired artifact versions into the parameters that we are just
+	// about to deploy. Injecting those parameters after all user inputs have been
+	// applied above guarantees that only the release versions as defined in the
+	// release source repository release will ever be applied.
 
-	{
+	for _, x := range c.cac.Releases() {
 		par = append(par, types.Parameter{
-			ParameterKey:   aws.String(constant.KayronTemplateVersion),
-			ParameterValue: aws.String(inf.Artifact.Reference.Desired),
+			ParameterKey:   aws.String(x.Parameter()),
+			ParameterValue: aws.String(x.Artifact.Reference.Desired),
 		})
 	}
 

--- a/pkg/operator/template/ensure.go
+++ b/pkg/operator/template/ensure.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"github.com/0xSplits/kayron/pkg/cache"
-	"github.com/0xSplits/kayron/pkg/constant"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/xh3b4sd/tracer"
@@ -29,7 +28,7 @@ func (t *Template) Ensure() error {
 
 	var ver string
 	{
-		ver = temVer(roo.Parameters)
+		ver = temVer(roo, inf)
 	}
 
 	t.log.Log(
@@ -58,9 +57,9 @@ func musStr(str string) string {
 	return str
 }
 
-func temVer(par []types.Parameter) string {
-	for _, x := range par {
-		if aws.ToString(x.ParameterKey) == constant.KayronTemplateVersion {
+func temVer(roo types.Stack, inf cache.Object) string {
+	for _, x := range roo.Parameters {
+		if aws.ToString(x.ParameterKey) == inf.Parameter() {
 			return aws.ToString(x.ParameterValue)
 		}
 	}


### PR DESCRIPTION
With this we can inject all release versions transparently as they are defined in the release source repository, in our case https://github.com/0xSplits/releases. The associated infrastructure change is at https://github.com/0xSplits/infrastructure/pull/12. 