### PR TITLE
prevent reconciliation on transitional stack states

### DIFF
--- a/cmd/deploy/run.go
+++ b/cmd/deploy/run.go
@@ -2,10 +2,11 @@ package deploy
 
 import (
 	"github.com/0xSplits/kayron/pkg/cache"
+	"github.com/0xSplits/kayron/pkg/cancel"
 	"github.com/0xSplits/kayron/pkg/envvar"
 	"github.com/0xSplits/kayron/pkg/operator"
-	"github.com/0xSplits/kayron/pkg/operator/policy"
 	"github.com/0xSplits/kayron/pkg/runtime"
+	"github.com/0xSplits/kayron/pkg/stack"
 	"github.com/0xSplits/otelgo/recorder"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/spf13/cobra"
@@ -54,6 +55,15 @@ func (r *run) runE(cmd *cobra.Command, arg []string) error {
 		})
 	}
 
+	var sta stack.Interface
+	{
+		sta = stack.New(stack.Config{
+			Aws: cfg,
+			Env: env,
+			Log: log,
+		})
+	}
+
 	var ope *operator.Operator
 	{
 		ope = operator.New(operator.Config{
@@ -62,6 +72,7 @@ func (r *run) runE(cmd *cobra.Command, arg []string) error {
 			Env: env,
 			Log: log,
 			Met: met,
+			Sta: sta,
 		})
 	}
 
@@ -72,7 +83,7 @@ func (r *run) runE(cmd *cobra.Command, arg []string) error {
 
 	{
 		err := fnc()
-		if policy.IsCancel(err) {
+		if cancel.Is(err) {
 			// fall through
 		} else if err != nil {
 			return tracer.Mask(err)

--- a/pkg/cancel/error.go
+++ b/pkg/cancel/error.go
@@ -1,0 +1,17 @@
+package cancel
+
+import (
+	"errors"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+var Error = &tracer.Error{
+	Description: "This error is used as control flow signal to instruct the worker engine that the current reconciliation loop should not execute any further.",
+}
+
+// Is is used to prevent cancel errors to be propagated inside the worker
+// engine's logs and metrics.
+func Is(err error) bool {
+	return errors.Is(err, Error)
+}

--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -4,9 +4,10 @@ import (
 	"time"
 
 	"github.com/0xSplits/kayron/pkg/cache"
+	"github.com/0xSplits/kayron/pkg/cancel"
 	"github.com/0xSplits/kayron/pkg/envvar"
 	"github.com/0xSplits/kayron/pkg/operator"
-	"github.com/0xSplits/kayron/pkg/operator/policy"
+	"github.com/0xSplits/kayron/pkg/stack"
 	"github.com/0xSplits/workit/handler"
 	"github.com/0xSplits/workit/worker"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,6 +26,15 @@ func (d *Daemon) Worker() *worker.Worker {
 		})
 	}
 
+	var sta stack.Interface
+	{
+		sta = stack.New(stack.Config{
+			Aws: cfg,
+			Env: d.env,
+			Log: d.log,
+		})
+	}
+
 	var ope *operator.Operator
 	{
 		ope = operator.New(operator.Config{
@@ -33,12 +43,13 @@ func (d *Daemon) Worker() *worker.Worker {
 			Env: d.env,
 			Log: d.log,
 			Met: d.met,
+			Sta: sta,
 		})
 	}
 
 	return worker.New(worker.Config{
 		Env: d.env.Environment,
-		Fil: policy.IsCancel,
+		Fil: cancel.Is,
 		Han: []handler.Interface{
 			handler.New(handler.Config{
 				Coo: 10 * time.Second,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xSplits/kayron/pkg/operator/registry"
 	"github.com/0xSplits/kayron/pkg/operator/release"
 	"github.com/0xSplits/kayron/pkg/operator/template"
+	"github.com/0xSplits/kayron/pkg/stack"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
@@ -26,6 +27,7 @@ type Config struct {
 	Env envvar.Env
 	Log logger.Interface
 	Met metric.Meter
+	Sta stack.Interface
 }
 
 type Operator struct {
@@ -55,6 +57,9 @@ func New(c Config) *Operator {
 	if c.Met == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
 	}
+	if c.Sta == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Sta must not be empty", c)))
+	}
 
 	return &Operator{
 		cloudFormation: cloudformation.New(cloudformation.Config{Aws: c.Aws, Cac: c.Cac, Dry: c.Dry, Env: c.Env, Log: c.Log, Met: c.Met}),
@@ -62,8 +67,8 @@ func New(c Config) *Operator {
 		infrastructure: infrastructure.New(infrastructure.Config{Aws: c.Aws, Cac: c.Cac, Dry: c.Dry, Env: c.Env, Log: c.Log}),
 		policy:         policy.New(policy.Config{Cac: c.Cac, Log: c.Log}),
 		reference:      reference.New(reference.Config{Cac: c.Cac, Env: c.Env, Log: c.Log}),
-		release:        release.New(release.Config{Cac: c.Cac, Env: c.Env, Log: c.Log}),
+		release:        release.New(release.Config{Aws: c.Aws, Cac: c.Cac, Env: c.Env, Log: c.Log, Sta: c.Sta}),
 		registry:       registry.New(registry.Config{Aws: c.Aws, Cac: c.Cac, Env: c.Env, Log: c.Log}),
-		template:       template.New(template.Config{Aws: c.Aws, Cac: c.Cac, Env: c.Env, Log: c.Log}),
+		template:       template.New(template.Config{Cac: c.Cac, Log: c.Log, Sta: c.Sta}),
 	}
 }

--- a/pkg/operator/operator_integration_test.go
+++ b/pkg/operator/operator_integration_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/0xSplits/kayron/pkg/cache"
+	"github.com/0xSplits/kayron/pkg/cancel"
 	"github.com/0xSplits/kayron/pkg/envvar"
-	"github.com/0xSplits/kayron/pkg/operator/policy"
 	"github.com/0xSplits/kayron/pkg/runtime"
+	"github.com/0xSplits/kayron/pkg/stack"
 	"github.com/0xSplits/otelgo/recorder"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/xh3b4sd/logger"
@@ -64,6 +65,15 @@ func Test_Operator_Integration(t *testing.T) {
 		})
 	}
 
+	var sta stack.Interface
+	{
+		sta = stack.New(stack.Config{
+			Aws: cfg,
+			Env: env,
+			Log: log,
+		})
+	}
+
 	var ope *Operator
 	{
 		ope = New(Config{
@@ -73,6 +83,7 @@ func Test_Operator_Integration(t *testing.T) {
 			Env: env,
 			Log: log,
 			Met: met,
+			Sta: sta,
 		})
 	}
 
@@ -83,7 +94,7 @@ func Test_Operator_Integration(t *testing.T) {
 
 	{
 		err := fnc()
-		if policy.IsCancel(err) {
+		if cancel.Is(err) {
 			// fall through
 		} else if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/pkg/operator/policy/ensure.go
+++ b/pkg/operator/policy/ensure.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"github.com/0xSplits/kayron/pkg/cancel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -58,12 +59,12 @@ func (p *Policy) Ensure() error {
 	// Cancel.
 
 	p.log.Log(
-		"level", "debug",
+		"level", "info",
 		"message", "cancelling reconciliation loop",
 		"reason", "no state drift",
 	)
 
-	return tracer.Mask(cancelError)
+	return tracer.Mask(cancel.Error)
 }
 
 func musStr(str string) string {

--- a/pkg/operator/policy/error.go
+++ b/pkg/operator/policy/error.go
@@ -1,24 +1,8 @@
 package policy
 
 import (
-	"errors"
-
 	"github.com/xh3b4sd/tracer"
 )
-
-var cancelError = &tracer.Error{
-	Description: "This error is used as control flow signal to instruct the worker engine that the current reconciliation loop should not execute any further.",
-}
-
-// IsCancel is used to prevent cancel errors to be propagated inside the worker
-// engine's logs and metrics.
-func IsCancel(err error) bool {
-	return errors.Is(err, cancelError)
-}
-
-//
-//
-//
 
 var cacheStateEmptyError = &tracer.Error{
 	Description: "This critical error indicates that some cached state of the current reconciliation loop was missing, which means that the operator does not know how to proceed safely.",

--- a/pkg/operator/release/canceler/canceler.go
+++ b/pkg/operator/release/canceler/canceler.go
@@ -1,0 +1,41 @@
+package canceler
+
+import (
+	"fmt"
+
+	"github.com/0xSplits/kayron/pkg/envvar"
+	"github.com/0xSplits/kayron/pkg/stack"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/xh3b4sd/tracer"
+)
+
+type Config struct {
+	Aws aws.Config
+	Env envvar.Env
+	Sta stack.Interface
+}
+
+type Canceler struct {
+	cfc *cloudformation.Client
+	env envvar.Env
+	sta stack.Interface
+}
+
+func New(c Config) *Canceler {
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
+	if c.Env.Environment == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Env must not be empty", c)))
+	}
+	if c.Sta == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Sta must not be empty", c)))
+	}
+
+	return &Canceler{
+		cfc: cloudformation.NewFromConfig(c.Aws),
+		env: c.Env,
+		sta: c.Sta,
+	}
+}

--- a/pkg/operator/release/canceler/error.go
+++ b/pkg/operator/release/canceler/error.go
@@ -1,0 +1,9 @@
+package canceler
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidStackStatusError = &tracer.Error{
+	Description: "This critical error indicates that the operator found the configured CloudFormation stack to be in a stack status that was unrecognizable, which means that the operator does not know how to proceed safely.",
+}

--- a/pkg/operator/release/canceler/interface.go
+++ b/pkg/operator/release/canceler/interface.go
@@ -1,0 +1,8 @@
+package canceler
+
+// Interface defines a network abstraction that decides whether any given
+// reconciliation loop should be cancelled early on.
+type Interface interface {
+	// Cancel returns true if the current reconciliation loop should be cancelled.
+	Cancel() (bool, error)
+}

--- a/pkg/operator/release/canceler/search.go
+++ b/pkg/operator/release/canceler/search.go
@@ -1,0 +1,71 @@
+package canceler
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/xh3b4sd/tracer"
+)
+
+var (
+	// status is a mapping of stack statuses answering the question if the current
+	// reconciliation loop should be cancelled given a certain stack status. E.g.
+	// should we cancel on UPDATE_COMPLETE=false? No, because the underlying
+	// CloudFormation stack is ready to be reconciled again after it has been
+	// updated previously.
+	status = map[types.StackStatus]bool{
+		// transitional progress states
+		types.StackStatusCreateInProgress:                        true,
+		types.StackStatusDeleteInProgress:                        true,
+		types.StackStatusImportInProgress:                        true,
+		types.StackStatusReviewInProgress:                        true,
+		types.StackStatusUpdateCompleteCleanupInProgress:         true,
+		types.StackStatusUpdateInProgress:                        true,
+		types.StackStatusImportRollbackInProgress:                true,
+		types.StackStatusRollbackInProgress:                      true,
+		types.StackStatusUpdateRollbackCompleteCleanupInProgress: true,
+		types.StackStatusUpdateRollbackInProgress:                true,
+
+		// unrecoverable final states
+		types.StackStatusCreateFailed:         true,
+		types.StackStatusDeleteFailed:         true,
+		types.StackStatusDeleteComplete:       true,
+		types.StackStatusImportRollbackFailed: true,
+		types.StackStatusRollbackComplete:     true,
+		types.StackStatusRollbackFailed:       true,
+		types.StackStatusUpdateFailed:         true,
+		types.StackStatusUpdateRollbackFailed: true,
+
+		// healthy final states
+		types.StackStatusCreateComplete:         false,
+		types.StackStatusImportComplete:         false,
+		types.StackStatusImportRollbackComplete: false,
+		types.StackStatusUpdateComplete:         false,
+		types.StackStatusUpdateRollbackComplete: false,
+	}
+)
+
+func (c *Canceler) Cancel() (bool, error) {
+	var err error
+
+	var sta types.Stack
+	{
+		sta, err = c.sta.Search()
+		if err != nil {
+			return false, tracer.Mask(err)
+		}
+	}
+
+	var can bool
+	var exi bool
+	{
+		can, exi = status[sta.StackStatus]
+	}
+
+	if !exi {
+		return false, tracer.Mask(invalidStackStatusError,
+			tracer.Context{Key: "stack", Value: c.env.CloudformationStack},
+			tracer.Context{Key: "status", Value: sta},
+		)
+	}
+
+	return can, nil
+}

--- a/pkg/operator/release/release.go
+++ b/pkg/operator/release/release.go
@@ -9,30 +9,40 @@ import (
 
 	"github.com/0xSplits/kayron/pkg/cache"
 	"github.com/0xSplits/kayron/pkg/envvar"
+	"github.com/0xSplits/kayron/pkg/operator/release/canceler"
 	"github.com/0xSplits/kayron/pkg/operator/release/resolver"
 	"github.com/0xSplits/kayron/pkg/roghfs"
+	"github.com/0xSplits/kayron/pkg/stack"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-github/v73/github"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
 )
 
 type Config struct {
+	Aws aws.Config
 	Cac *cache.Cache
 	Env envvar.Env
 	Log logger.Interface
+	Sta stack.Interface
 }
 
 type Release struct {
 	cac *cache.Cache
+	can canceler.Interface
 	env envvar.Env
 	git *github.Client
 	log logger.Interface
 	own string
 	rep string
 	res resolver.Interface
+	sta stack.Interface
 }
 
 func New(c Config) *Release {
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
 	if c.Cac == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Cac must not be empty", c)))
 	}
@@ -41,6 +51,9 @@ func New(c Config) *Release {
 	}
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+	if c.Sta == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Sta must not be empty", c)))
 	}
 
 	var err error
@@ -59,6 +72,15 @@ func New(c Config) *Release {
 		}
 	}
 
+	var can canceler.Interface
+	{
+		can = canceler.New(canceler.Config{
+			Aws: c.Aws,
+			Env: c.Env,
+			Sta: c.Sta,
+		})
+	}
+
 	var res resolver.Interface
 	{
 		res = resolver.New(resolver.Config{
@@ -70,11 +92,13 @@ func New(c Config) *Release {
 
 	return &Release{
 		cac: c.Cac,
+		can: can,
 		env: c.Env,
 		git: git,
 		log: c.Log,
 		own: own,
 		rep: rep,
 		res: res,
+		sta: c.Sta,
 	}
 }

--- a/pkg/operator/template/ensure.go
+++ b/pkg/operator/template/ensure.go
@@ -17,7 +17,7 @@ func (t *Template) Ensure() error {
 
 	var roo types.Stack
 	{
-		roo, err = t.rooSta()
+		roo, err = t.sta.Search()
 		if err != nil {
 			return tracer.Mask(err)
 		}

--- a/pkg/operator/template/error.go
+++ b/pkg/operator/template/error.go
@@ -1,9 +1,0 @@
-package template
-
-import (
-	"github.com/xh3b4sd/tracer"
-)
-
-var invalidRootStackError = &tracer.Error{
-	Description: "The operator expected to find exactly one root stack for the configured stack name, but no root stack was found for the given environment.",
-}

--- a/pkg/operator/template/template.go
+++ b/pkg/operator/template/template.go
@@ -7,48 +7,37 @@ import (
 	"fmt"
 
 	"github.com/0xSplits/kayron/pkg/cache"
-	"github.com/0xSplits/kayron/pkg/envvar"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	"github.com/0xSplits/kayron/pkg/stack"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
 )
 
 type Config struct {
-	Aws aws.Config
 	Cac *cache.Cache
-	Env envvar.Env
 	Log logger.Interface
+	Sta stack.Interface
 }
 
 type Template struct {
-	cfc *cloudformation.Client
 	cac *cache.Cache
-	env envvar.Env
 	log logger.Interface
-	tag *resourcegroupstaggingapi.Client
+	sta stack.Interface
 }
 
 func New(c Config) *Template {
-	if c.Aws.Region == "" {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
-	}
 	if c.Cac == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Cac must not be empty", c)))
-	}
-	if c.Env.Environment == "" {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Env must not be empty", c)))
 	}
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
+	if c.Sta == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Sta must not be empty", c)))
+	}
 
 	return &Template{
-		cfc: cloudformation.NewFromConfig(c.Aws),
 		cac: c.Cac,
-		env: c.Env,
 		log: c.Log,
-		tag: resourcegroupstaggingapi.NewFromConfig(c.Aws),
+		sta: c.Sta,
 	}
 }

--- a/pkg/stack/delete.go
+++ b/pkg/stack/delete.go
@@ -1,0 +1,7 @@
+package stack
+
+func (s *Stack) Delete() {
+	s.mut.Lock()
+	s.sta = nil
+	s.mut.Unlock()
+}

--- a/pkg/stack/error.go
+++ b/pkg/stack/error.go
@@ -1,0 +1,9 @@
+package stack
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidRootStackError = &tracer.Error{
+	Description: "This critical error indicates that the operator could not find the configured root stack for the given environment, which means that the operator does not know how to proceed safely.",
+}

--- a/pkg/stack/interface.go
+++ b/pkg/stack/interface.go
@@ -1,0 +1,15 @@
+package stack
+
+import "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+
+type Interface interface {
+	// Delete purges the underlying local cache, causing Search to fetch the
+	// latest version of the stack object state again over network.
+	Delete()
+
+	// Search returns the state of the configured stack object and caches the
+	// first valid search result so that consecutive executions of Search prevent
+	// network calls. This behaviour guarantees consistent stack object state
+	// within reconciliation loops.
+	Search() (types.Stack, error)
+}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -1,0 +1,47 @@
+package stack
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/0xSplits/kayron/pkg/envvar"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+)
+
+type Config struct {
+	Aws aws.Config
+	Env envvar.Env
+	Log logger.Interface
+}
+
+type Stack struct {
+	cfc *cloudformation.Client
+	sta *types.Stack
+	env envvar.Env
+	log logger.Interface
+	mut sync.Mutex
+}
+
+func New(c Config) *Stack {
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
+	if c.Env.Environment == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Env must not be empty", c)))
+	}
+	if c.Log == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+
+	return &Stack{
+		cfc: cloudformation.NewFromConfig(c.Aws),
+		sta: nil,
+		env: c.Env,
+		log: c.Log,
+		mut: sync.Mutex{},
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/splits/issue/PE-4651/make-kayron-aware-of-ongoing-stack-updates.