### PR TITLE
configure linter with folder whitelist

### DIFF
--- a/cmd/lint/run.go
+++ b/cmd/lint/run.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"github.com/0xSplits/kayron/pkg/constant"
 	"github.com/0xSplits/kayron/pkg/release/loader"
 	"github.com/0xSplits/kayron/pkg/release/schema"
 	"github.com/spf13/afero"
@@ -22,7 +23,7 @@ func (r *run) runE(cmd *cobra.Command, arg []string) error {
 
 	var sch schema.Schema
 	{
-		sch, err = loader.Loader(sys, r.flag.Pat)
+		sch, err = loader.Loader(sys, r.flag.Pat, constant.Infrastructure, constant.Service)
 		if err != nil {
 			return tracer.Mask(err)
 		}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -2,4 +2,6 @@ package constant
 
 const (
 	Cloudformation = "cloudformation"
+	Infrastructure = "./infrastructure/"
+	Service        = "./service/"
 )

--- a/pkg/operator/release/ensure.go
+++ b/pkg/operator/release/ensure.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"github.com/0xSplits/kayron/pkg/cancel"
+	"github.com/0xSplits/kayron/pkg/constant"
 	"github.com/0xSplits/kayron/pkg/operator/release/resolver"
 	"github.com/0xSplits/kayron/pkg/release/loader"
 	"github.com/0xSplits/kayron/pkg/release/schema"
@@ -96,7 +97,7 @@ func (r *Release) Ensure() error {
 
 	var sch schema.Schema
 	{
-		sch, err = loader.Loader(gfs, ".", "./infrastructure/", "./service/")
+		sch, err = loader.Loader(gfs, ".", constant.Infrastructure, constant.Service)
 		if err != nil {
 			return tracer.Mask(err)
 		}


### PR DESCRIPTION
We introduced a folder whitelist in https://github.com/0xSplits/kayron/pull/45 so that Kayron finds the desired release definitions without adding any other .yaml files to the mix. Here we set the same whitelist for the linter command.

Note that this did not fail for the linter action in the releases repository because there we run Kayron in Docker and only mount the infrastructure and service folders directly into the container, which acts as a whitelist on a different level. See https://github.com/0xSplits/releases/blob/main/.github/workflows/release-lint.yaml.