### PR TITLE
reorder infrastructure condition for policy awareness

### DIFF
--- a/pkg/operator/infrastructure/ensure.go
+++ b/pkg/operator/infrastructure/ensure.go
@@ -85,16 +85,5 @@ func (i *Infrastructure) Ensure() error {
 		}
 	}
 
-	// Once all infrastructure templates have been uploaded to S3, we can set the
-	// condition success for this particular release artifact.
-
-	{
-		inf.Artifact.Condition.Success = true
-	}
-
-	{
-		i.cac.Update(inf)
-	}
-
 	return nil
 }

--- a/pkg/operator/template/ensure.go
+++ b/pkg/operator/template/ensure.go
@@ -24,7 +24,8 @@ func (t *Template) Ensure() error {
 	}
 
 	// Once we have found the root stack for this environment, we can set the
-	// current state for this particular release artifact.
+	// current state and the condition success for this particular release
+	// artifact.
 
 	var ver string
 	{
@@ -39,6 +40,7 @@ func (t *Template) Ensure() error {
 	)
 
 	{
+		inf.Artifact.Condition.Success = true
 		inf.Artifact.Scheduler.Current = ver
 	}
 


### PR DESCRIPTION
The policy function checks if any valid state drift exists given a set of releases. The validity of the infrastructure release was invisible to the policy function, because we set the infrastructure condition to `true` only after the policy function already ran.

Why did the integration test not catch this? The integration test is just a naive smoke test that verifies **consistency** in terms of data races. The integration test that we have today does not check for **accuracy**. Thinking about ways to improve this, I created https://linear.app/splits/issue/PE-4659/enable-kayron-integration-test-to-also-verify-accuracy. 

Looking at the current operator design and the changes made here, we moved the condition update from the `infrastructure` step to the `template` step. And so this fix works because the condition update is done before our `policy` module looks at the cached state.

<img width="1353" height="620" alt="Screenshot 2025-08-18 at 14 58 44" src="https://github.com/user-attachments/assets/4889475e-b114-4622-9cc9-213dc3c263b9" />

---

Running the integration test locally we can see that the reconciliation loop is not cancelled anymore, because the operator sees the state drift for the infrastructure release.

```
# before
{
    "time": "2025-08-18 11:29:02",
    "level": "info",
    "message": "cancelling reconciliation loop",
    "reason": "no state drift",
    "caller": "/build/pkg/operator/policy/ensure.go:61"
}

# after 
{
    "time": "2025-08-18 12:41:55",
    "level": "info",
    "message": "continuing reconciliation loop",
    "reason": "detected state drift",
    "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/operator/policy/ensure.go:46"
}