### PR TITLE
trigger docker push for commits and releases

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -6,6 +6,13 @@ on:
     # skip running the workflow in branches that dependabot presumably created.
     branches-ignore:
       - "dependabot/**"
+    # Trigger this workflow on all branch updates where a new commit is being
+    # pushed.
+    branches:
+      - "**"
+    # Trigger this workflow for all new releases that create a Git tag.
+    tags:
+      - "v*.*.*"
 
 jobs:
   docker-push:

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -6,10 +6,6 @@ on:
     # skip running the workflow in branches that dependabot presumably created.
     branches-ignore:
       - "dependabot/**"
-    # Trigger this workflow on all branch updates where a new commit is being
-    # pushed.
-    branches:
-      - "**"
     # Trigger this workflow for all new releases that create a Git tag.
     tags:
       - "v*.*.*"

--- a/pkg/operator/cloudformation/ensure.go
+++ b/pkg/operator/cloudformation/ensure.go
@@ -42,7 +42,7 @@ func (c *CloudFormation) Ensure() error {
 	}
 
 	c.log.Log(
-		"level", "debug",
+		"level", "info",
 		"message", "updating cloudformation stack",
 		"name", c.env.CloudformationStack,
 	)


### PR DESCRIPTION
The latest change to the docker push workflow did not trigger for releases anymore.