### PR TITLE
support version parameter names with dashes like splits-lite

### DIFF
--- a/pkg/cache/object.go
+++ b/pkg/cache/object.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/0xSplits/kayron/pkg/release/artifact"
 	"github.com/0xSplits/kayron/pkg/release/schema/release"
@@ -46,7 +47,7 @@ func (o Object) Name() string {
 // CloudFormation template being deployed, e.g. InfrastructureVersion,
 // SpectaVersion.
 func (o Object) Parameter() string {
-	return fmt.Sprintf("%sVersion", cases.Title(language.English).String(o.Name()))
+	return fmt.Sprintf("%sVersion", strings.Map(mapFnc, cases.Title(language.English).String(o.Name())))
 }
 
 // Version returns the desired state of this artifact's release version if the
@@ -69,4 +70,13 @@ func (o Object) Version() string {
 	}
 
 	return o.Artifact.Reference.Desired
+}
+
+// mapFnc signals the removal of dashes and spaces only.
+func mapFnc(r rune) rune {
+	if r == '-' || r == ' ' {
+		return -1
+	}
+
+	return r
 }

--- a/pkg/cache/object_test.go
+++ b/pkg/cache/object_test.go
@@ -46,6 +46,14 @@ func Test_Cache_Object_Parameter(t *testing.T) {
 			},
 			par: "FoobarVersion",
 		},
+		// Case 004, with dash
+		{
+			obj: Object{
+				Release: release.Struct{Docker: docker.String("splits-lite")},
+				kin:     Service,
+			},
+			par: "SplitsLiteVersion",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/operator/policy/ensure.go
+++ b/pkg/operator/policy/ensure.go
@@ -23,10 +23,11 @@ func (p *Policy) ensure(rel []cache.Object) error {
 	// and checking their cashed state before doing anything else. We must not
 	// continue this reconciliation loop if there is any empty or invalid state,
 	// because the side effects of proceeding using such a broken state could
-	// potentially be dangerous.
+	// potentially be dangerous. Note that verification is skipped for those
+	// releases that are suspended.
 
 	for _, x := range rel {
-		if x.Artifact.Empty() {
+		if !bool(x.Release.Deploy.Suspend) && x.Artifact.Empty() {
 			p.log.Log(
 				"level", "warning",
 				"message", "cancelling reconciliation loop",


### PR DESCRIPTION
When I was trying to deploy Splits Lite the first time, I saw that the operator couldn't work with dashes in repository names. 