### PR TITLE
fix template url by properly using the injected environment name

### DIFF
--- a/pkg/operator/cloudformation/ensure.go
+++ b/pkg/operator/cloudformation/ensure.go
@@ -22,10 +22,16 @@ func (c *CloudFormation) Ensure() error {
 		})
 	}
 
+	var url string
+	{
+		url = c.temUrl()
+	}
+
 	c.log.Log(
 		"level", "info",
 		"message", "updating cloudformation stack",
 		"name", c.env.CloudformationStack,
+		"url", url,
 	)
 
 	// Make sure we respect the dry run flag when attempting to update any stack
@@ -37,7 +43,7 @@ func (c *CloudFormation) Ensure() error {
 	{
 		inp = &cloudformation.UpdateStackInput{
 			StackName:   aws.String(c.env.CloudformationStack),
-			TemplateURL: aws.String(c.temUrl()),
+			TemplateURL: aws.String(url),
 			Parameters:  c.temPar(c.cac.Releases()),
 			Capabilities: []types.Capability{
 				types.CapabilityCapabilityIam,
@@ -87,10 +93,11 @@ func (c *CloudFormation) temPar(rel []cache.Object) []types.Parameter {
 			ParameterValue: aws.String(x.Version()),
 		})
 	}
-
 	return par
 }
 
+// temUrl returns the environment specific template URL for the root stack
+// CloudFormation template.
 func (c *CloudFormation) temUrl() string {
-	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/testing/index.yaml", c.env.S3Bucket, c.cfc.Options().Region)
+	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s/index.yaml", c.env.S3Bucket, c.cfc.Options().Region, c.env.Environment)
 }

--- a/pkg/operator/container/task.go
+++ b/pkg/operator/container/task.go
@@ -65,7 +65,7 @@ func (c *Container) task(det []detail) ([]task, error) {
 			if tag == "" {
 				c.log.Log(
 					"level", "warning",
-					"message", "skipping instrumentation for ECS service",
+					"message", "skipping reconciliation for ECS service",
 					"reason", "ECS service has no 'service' tag",
 					"cluster", *x.ClusterArn,
 					"service", *x.ServiceArn,

--- a/pkg/operator/reference/github.go
+++ b/pkg/operator/reference/github.go
@@ -9,8 +9,9 @@ import (
 
 func (r *Reference) desRef(rel release.Struct) (string, error) {
 	// Return the commit sha if the branch deployment strategy is selected. Note
-	// that branches may be defined while they are not yet tracked inside of
-	// Github.
+	// that branches may be referenced in releases while they are not yet tracked,
+	// or not tracked anymore inside of Github. This may happen predominantly
+	// during testing when preparing or finishing releases and their dependencies.
 
 	if !rel.Deploy.Branch.Empty() {
 		sha, err := r.comSha(rel.Github.String(), rel.Deploy.Branch.String())


### PR DESCRIPTION
I just noticed that **I made an absolute blunder** here, because all environments were hard coded to use the templates of the `testing` environment. This has not been an issue so far because we have been rolling all environments from `testing` to `staging` to `production` without forward breaking changes. But now that we introduced a new parameter to the root stack template, we saw a super weird error in the Kayron logs in `staging`.