### PR TITLE
handle missing feature branches more gracefully

### DIFF
--- a/pkg/operator/policy/ensure.go
+++ b/pkg/operator/policy/ensure.go
@@ -39,7 +39,7 @@ func (p *Policy) ensure(rel []cache.Object) error {
 				"desired", musStr(x.Artifact.Reference.Desired),
 			)
 
-			return tracer.Mask(cacheStateEmptyError)
+			return tracer.Mask(cancel.Error)
 		}
 	}
 

--- a/pkg/operator/policy/error.go
+++ b/pkg/operator/policy/error.go
@@ -1,13 +1,5 @@
 package policy
 
-import (
-	"github.com/xh3b4sd/tracer"
-)
-
-var cacheStateEmptyError = &tracer.Error{
-	Description: "This critical error indicates that some cached state of the current reconciliation loop was missing, which means that the operator does not know how to proceed safely.",
-}
-
 //
 //
 //

--- a/pkg/operator/registry/ensure.go
+++ b/pkg/operator/registry/ensure.go
@@ -28,9 +28,10 @@ func (r *Registry) Ensure() error {
 		}
 
 		// We do not have to do any work here if the currently deployed service
-		// already matches the desired service release.
+		// already matches the desired service release, or if we could not resolve
+		// it at all in a previous step.
 
-		if cur == des {
+		if cur == des || des == "" {
 			return nil
 		}
 


### PR DESCRIPTION
I have noticed that Kayron throws some unintended errors under normal operations when humans delete feature branches in their repositories while still referencing those deleted branches in some release definitions. This current behaviour also fails the integration tests. We should not emit errors in those cases because there isn't anything wrong necessarily. With this change we should rather see some warning logs like shown below.

```json
{
    "time": "2025-09-22 09:54:19",
    "level": "warning",
    "message": "git ref unresolvable",
    "branch": "instant",
    "owner": "0xSplits",
    "reason": "branch not found",
    "repository": "kayron",
    "suggestion": "this issue might be caused by a user error or eventual consistency of the underlying backend",
    "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/operator/reference/github.go:43"
}
{
    "time": "2025-09-22 09:54:20",
    "level": "warning",
    "message": "cancelling reconciliation loop",
    "current": "8a77752b1ee04a91648877c8eef504fe5b0e94b7",
    "desired": "''",
    "docker": "kayron",
    "github": "kayron",
    "reason": "invalid artifact cache",
    "caller": "/Users/xh3b4sd/project/0xSplits/kayron/pkg/operator/policy/ensure.go:31"
}
```